### PR TITLE
Include the sd processor by default and use a more standard name.

### DIFF
--- a/processor/prometheusdiscoveryprocessor/factory.go
+++ b/processor/prometheusdiscoveryprocessor/factory.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "prometheusdiscovery"
+	typeStr = "prometheus_discovery"
 )
 
 var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: true}

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
 	"go.opentelemetry.io/collector/processor/filterprocessor"
+	"go.opentelemetry.io/collector/processor/prometheusdiscoveryprocessor"
 	"go.opentelemetry.io/collector/processor/memorylimiter"
 	"go.opentelemetry.io/collector/processor/probabilisticsamplerprocessor"
 	"go.opentelemetry.io/collector/processor/resourceprocessor"
@@ -103,6 +104,7 @@ func Components() (
 		probabilisticsamplerprocessor.NewFactory(),
 		spanprocessor.NewFactory(),
 		filterprocessor.NewFactory(),
+		prometheusdiscoveryprocessor.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
`prometheus_discovery` follows the standard, i.e. `memory_limiter`.