### PR TITLE
Instrument obsreport.Processor

### DIFF
--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -139,11 +139,11 @@ func (proc *Processor) createOtelMetrics(cfg ProcessorSettings) {
 	handleError(obsmetrics.ProcessorPrefix+obsmetrics.DroppedSpansKey, err)
 
 	proc.acceptedMetricPointsCounter, err = meter.SyncInt64().Counter(
-		obsmetrics.ReceiverPrefix+obsmetrics.AcceptedMetricPointsKey,
+		obsmetrics.ProcessorPrefix+obsmetrics.AcceptedMetricPointsKey,
 		instrument.WithDescription("Number of metric points successfully pushed into the next component in the pipeline."),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	handleError(obsmetrics.ReceiverPrefix+obsmetrics.AcceptedMetricPointsKey, err)
+	handleError(obsmetrics.ProcessorPrefix+obsmetrics.AcceptedMetricPointsKey, err)
 
 	proc.refusedMetricPointsCounter, err = meter.SyncInt64().Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.RefusedMetricPointsKey,
@@ -180,40 +180,6 @@ func (proc *Processor) createOtelMetrics(cfg ProcessorSettings) {
 	)
 	handleError(obsmetrics.ProcessorPrefix+obsmetrics.DroppedLogRecordsKey, err)
 }
-
-// func (por *Processor) recordMetrics(ctx context.Context, dataType config.DataType, accepted, refused, dropped int64) {
-// 	if por.useOtelForMetrics {
-// 		por.recordWithOtel(ctx, dataType, accepted, refused, dropped)
-// 	} else {
-// 		por.recordWithOC(ctx, dataType, accepted, refused, dropped)
-// 	}
-// }
-
-// func (por *Processor) recordWithOtel(ctx context.Context, dataType config.DataType, accepted, refused, dropped int64) {
-// 	var acceptedCounter, refusedCounter, droppedCounter syncint64.Counter
-	
-// 	switch dataType {
-// 	case config.TracesDataType:
-// 		acceptedCounter = por.acceptedSpansCounter
-// 		refusedCounter = por.refusedSpansCounter
-// 		droppedCounter = por.droppedSpansCounter
-// 	case config.MetricsDataType:
-// 		acceptedCounter = por.acceptedMetricPointsCounter
-// 		refusedCounter = por.refusedMetricPointsCounter
-// 		droppedCounter = por.droppedMetricPointsCounter
-// 	case config.LogsDataType:
-// 		acceptedCounter = por.acceptedLogRecordsCounter
-// 		refusedCounter = por.refusedLogRecordsCounter
-// 		droppedCounter = por.droppedLogRecordsCounter
-// 	}
-
-// 	acceptedCounter.Add(ctx, int64(accepted), por.otelAttrs...)
-// 	refusedCounter.Add(ctx, int64(refused), por.otelAttrs...)
-// 	droppedCounter.Add(ctx, int64(dropped), por.otelAttrs...)
-// }
-
-// func (por *Processor) recordWithOC(ctx context.Context, dataType, config.DataType)
-
 
 // TracesAccepted reports that the trace data was accepted.
 func (por *Processor) TracesAccepted(ctx context.Context, numSpans int) {
@@ -283,7 +249,7 @@ func (por *Processor) MetricsAccepted(ctx context.Context, numPoints int) {
 	}
 
 	if por.useOtelForMetrics {
-		por.acceptedMetricPointsCounter.Add(ctx, int64(numPoints), )
+		por.acceptedMetricPointsCounter.Add(ctx, int64(numPoints), por.otelAttrs...)
 	} else {
 		// ignore the error for now; should not happen
 		_ = stats.RecordWithTags(

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -479,45 +479,38 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 }
 
 func TestProcessorTraceData(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+	testTelemetry(t, func(tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+		const acceptedSpans = 27
+		const refusedSpans = 19
+		const droppedSpans = 13
+		obsrep := newProcessor(ProcessorSettings{
+			ProcessorID:             processor,
+			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+		}, registry)
+		obsrep.TracesAccepted(context.Background(), acceptedSpans)
+		obsrep.TracesRefused(context.Background(), refusedSpans)
+		obsrep.TracesDropped(context.Background(), droppedSpans)
 
-	const acceptedSpans = 27
-	const refusedSpans = 19
-	const droppedSpans = 13
-
-	obsrep, err := NewProcessor(ProcessorSettings{
-		ProcessorID:             processor,
-		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+		require.NoError(t, obsreporttest.CheckProcessorTraces(tt, processor, acceptedSpans, refusedSpans, droppedSpans))
 	})
-	require.NoError(t, err)
-	obsrep.TracesAccepted(context.Background(), acceptedSpans)
-	obsrep.TracesRefused(context.Background(), refusedSpans)
-	obsrep.TracesDropped(context.Background(), droppedSpans)
-
-	require.NoError(t, obsreporttest.CheckProcessorTraces(tt, processor, acceptedSpans, refusedSpans, droppedSpans))
 }
 
 func TestProcessorMetricsData(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+	testTelemetry(t, func(tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+		const acceptedPoints = 29
+		const refusedPoints = 11
+		const droppedPoints = 17
 
-	const acceptedPoints = 29
-	const refusedPoints = 11
-	const droppedPoints = 17
+		obsrep := newProcessor(ProcessorSettings{
+			ProcessorID:             processor,
+			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+		}, registry)
+		obsrep.MetricsAccepted(context.Background(), acceptedPoints)
+		obsrep.MetricsRefused(context.Background(), refusedPoints)
+		obsrep.MetricsDropped(context.Background(), droppedPoints)
 
-	obsrep, err := NewProcessor(ProcessorSettings{
-		ProcessorID:             processor,
-		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+		require.NoError(t, obsreporttest.CheckProcessorMetrics(tt, processor, acceptedPoints, refusedPoints, droppedPoints))
 	})
-	require.NoError(t, err)
-	obsrep.MetricsAccepted(context.Background(), acceptedPoints)
-	obsrep.MetricsRefused(context.Background(), refusedPoints)
-	obsrep.MetricsDropped(context.Background(), droppedPoints)
-
-	require.NoError(t, obsreporttest.CheckProcessorMetrics(tt, processor, acceptedPoints, refusedPoints, droppedPoints))
 }
 
 func TestBuildProcessorCustomMetricName(t *testing.T) {
@@ -543,22 +536,19 @@ func TestBuildProcessorCustomMetricName(t *testing.T) {
 }
 
 func TestProcessorLogRecords(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+	testTelemetry(t, func(tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+		const acceptedRecords = 29
+		const refusedRecords = 11
+		const droppedRecords = 17
 
-	const acceptedRecords = 29
-	const refusedRecords = 11
-	const droppedRecords = 17
+		obsrep := newProcessor(ProcessorSettings{
+			ProcessorID:             processor,
+			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+		}, registry)
+		obsrep.LogsAccepted(context.Background(), acceptedRecords)
+		obsrep.LogsRefused(context.Background(), refusedRecords)
+		obsrep.LogsDropped(context.Background(), droppedRecords)
 
-	obsrep, err := NewProcessor(ProcessorSettings{
-		ProcessorID:             processor,
-		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+		require.NoError(t, obsreporttest.CheckProcessorLogs(tt, processor, acceptedRecords, refusedRecords, droppedRecords))
 	})
-	require.NoError(t, err)
-	obsrep.LogsAccepted(context.Background(), acceptedRecords)
-	obsrep.LogsRefused(context.Background(), refusedRecords)
-	obsrep.LogsDropped(context.Background(), droppedRecords)
-
-	require.NoError(t, obsreporttest.CheckProcessorLogs(tt, processor, acceptedRecords, refusedRecords, droppedRecords))
 }

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -479,25 +479,30 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 }
 
 func TestProcessorTraceData(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
-		const acceptedSpans = 27
-		const refusedSpans = 19
-		const droppedSpans = 13
-		obsrep, err := newProcessor(ProcessorSettings{
-			ProcessorID:             processor,
-			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
-		}, registry)
-		require.NoError(t, err)
-		obsrep.TracesAccepted(context.Background(), acceptedSpans)
-		obsrep.TracesRefused(context.Background(), refusedSpans)
-		obsrep.TracesDropped(context.Background(), droppedSpans)
+	testTelemetry(t, testProcessorTraceData)
+}
 
-		require.NoError(t, obsreporttest.CheckProcessorTraces(tt, processor, acceptedSpans, refusedSpans, droppedSpans))
-	})
+func testProcessorTraceData(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	const acceptedSpans = 27
+	const refusedSpans = 19
+	const droppedSpans = 13
+	obsrep, err := newProcessor(ProcessorSettings{
+		ProcessorID:             processor,
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+	}, registry)
+	require.NoError(t, err)
+	obsrep.TracesAccepted(context.Background(), acceptedSpans)
+	obsrep.TracesRefused(context.Background(), refusedSpans)
+	obsrep.TracesDropped(context.Background(), droppedSpans)
+
+	require.NoError(t, obsreporttest.CheckProcessorTraces(tt, processor, acceptedSpans, refusedSpans, droppedSpans))
 }
 
 func TestProcessorMetricsData(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, testProcessorMetricsData)
+}
+
+func testProcessorMetricsData(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		const acceptedPoints = 29
 		const refusedPoints = 11
 		const droppedPoints = 17
@@ -512,7 +517,6 @@ func TestProcessorMetricsData(t *testing.T) {
 		obsrep.MetricsDropped(context.Background(), droppedPoints)
 
 		require.NoError(t, obsreporttest.CheckProcessorMetrics(tt, processor, acceptedPoints, refusedPoints, droppedPoints))
-	})
 }
 
 func TestBuildProcessorCustomMetricName(t *testing.T) {
@@ -538,20 +542,22 @@ func TestBuildProcessorCustomMetricName(t *testing.T) {
 }
 
 func TestProcessorLogRecords(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
-		const acceptedRecords = 29
-		const refusedRecords = 11
-		const droppedRecords = 17
+	testTelemetry(t, testProcessorLogRecords)
+}
 
-		obsrep, err := newProcessor(ProcessorSettings{
-			ProcessorID:             processor,
-			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
-		}, registry)
-		require.NoError(t, err)
-		obsrep.LogsAccepted(context.Background(), acceptedRecords)
-		obsrep.LogsRefused(context.Background(), refusedRecords)
-		obsrep.LogsDropped(context.Background(), droppedRecords)
+func testProcessorLogRecords(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	const acceptedRecords = 29
+	const refusedRecords = 11
+	const droppedRecords = 17
 
-		require.NoError(t, obsreporttest.CheckProcessorLogs(tt, processor, acceptedRecords, refusedRecords, droppedRecords))
-	})
+	obsrep, err := newProcessor(ProcessorSettings{
+		ProcessorID:             processor,
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+	}, registry)
+	require.NoError(t, err)
+	obsrep.LogsAccepted(context.Background(), acceptedRecords)
+	obsrep.LogsRefused(context.Background(), refusedRecords)
+	obsrep.LogsDropped(context.Background(), droppedRecords)
+
+	require.NoError(t, obsreporttest.CheckProcessorLogs(tt, processor, acceptedRecords, refusedRecords, droppedRecords))
 }

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -479,14 +479,15 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 }
 
 func TestProcessorTraceData(t *testing.T) {
-	testTelemetry(t, func(tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		const acceptedSpans = 27
 		const refusedSpans = 19
 		const droppedSpans = 13
-		obsrep := newProcessor(ProcessorSettings{
+		obsrep, err := newProcessor(ProcessorSettings{
 			ProcessorID:             processor,
 			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 		}, registry)
+		require.NoError(t, err)
 		obsrep.TracesAccepted(context.Background(), acceptedSpans)
 		obsrep.TracesRefused(context.Background(), refusedSpans)
 		obsrep.TracesDropped(context.Background(), droppedSpans)
@@ -496,15 +497,16 @@ func TestProcessorTraceData(t *testing.T) {
 }
 
 func TestProcessorMetricsData(t *testing.T) {
-	testTelemetry(t, func(tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		const acceptedPoints = 29
 		const refusedPoints = 11
 		const droppedPoints = 17
 
-		obsrep := newProcessor(ProcessorSettings{
+		obsrep, err := newProcessor(ProcessorSettings{
 			ProcessorID:             processor,
 			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 		}, registry)
+		require.NoError(t, err)
 		obsrep.MetricsAccepted(context.Background(), acceptedPoints)
 		obsrep.MetricsRefused(context.Background(), refusedPoints)
 		obsrep.MetricsDropped(context.Background(), droppedPoints)
@@ -536,15 +538,16 @@ func TestBuildProcessorCustomMetricName(t *testing.T) {
 }
 
 func TestProcessorLogRecords(t *testing.T) {
-	testTelemetry(t, func(tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		const acceptedRecords = 29
 		const refusedRecords = 11
 		const droppedRecords = 17
 
-		obsrep := newProcessor(ProcessorSettings{
+		obsrep, err := newProcessor(ProcessorSettings{
 			ProcessorID:             processor,
 			ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 		}, registry)
+		require.NoError(t, err)
 		obsrep.LogsAccepted(context.Background(), acceptedRecords)
 		obsrep.LogsRefused(context.Background(), refusedRecords)
 		obsrep.LogsDropped(context.Background(), droppedRecords)

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -157,32 +157,20 @@ func CheckExporterLogs(tts TestTelemetry, exporter component.ID, sentLogRecords,
 
 // CheckProcessorTraces checks that for the current exported values for trace exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorTraces(_ TestTelemetry, processor component.ID, acceptedSpans, refusedSpans, droppedSpans int64) error {
-	processorTags := tagsForProcessorView(processor)
-	return multierr.Combine(
-		checkValueForView(processorTags, acceptedSpans, "processor/accepted_spans"),
-		checkValueForView(processorTags, refusedSpans, "processor/refused_spans"),
-		checkValueForView(processorTags, droppedSpans, "processor/dropped_spans"))
+func CheckProcessorTraces(tts TestTelemetry, processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
+	return tts.otelPrometheusChecker.checkProcessorTraces(processor, acceptedSpans, refusedSpans, droppedSpans)
 }
 
 // CheckProcessorMetrics checks that for the current exported values for metrics exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorMetrics(_ TestTelemetry, processor component.ID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
-	processorTags := tagsForProcessorView(processor)
-	return multierr.Combine(
-		checkValueForView(processorTags, acceptedMetricPoints, "processor/accepted_metric_points"),
-		checkValueForView(processorTags, refusedMetricPoints, "processor/refused_metric_points"),
-		checkValueForView(processorTags, droppedMetricPoints, "processor/dropped_metric_points"))
+func CheckProcessorMetrics(tts TestTelemetry, processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
+	return tts.otelPrometheusChecker.checkProcessorMetrics(processor, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints)
 }
 
 // CheckProcessorLogs checks that for the current exported values for logs exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorLogs(_ TestTelemetry, processor component.ID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
-	processorTags := tagsForProcessorView(processor)
-	return multierr.Combine(
-		checkValueForView(processorTags, acceptedLogRecords, "processor/accepted_log_records"),
-		checkValueForView(processorTags, refusedLogRecords, "processor/refused_log_records"),
-		checkValueForView(processorTags, droppedLogRecords, "processor/dropped_log_records"))
+func CheckProcessorLogs(tts TestTelemetry, processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
+	return tts.otelPrometheusChecker.checkProcessorLogs(processor, acceptedLogRecords, refusedLogRecords, droppedLogRecords)
 }
 
 // CheckReceiverTraces checks that for the current exported values for trace receiver metrics match given values.

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -157,19 +157,19 @@ func CheckExporterLogs(tts TestTelemetry, exporter component.ID, sentLogRecords,
 
 // CheckProcessorTraces checks that for the current exported values for trace exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorTraces(tts TestTelemetry, processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
+func CheckProcessorTraces(tts TestTelemetry, processor component.ID, acceptedSpans, refusedSpans, droppedSpans int64) error {
 	return tts.otelPrometheusChecker.checkProcessorTraces(processor, acceptedSpans, refusedSpans, droppedSpans)
 }
 
 // CheckProcessorMetrics checks that for the current exported values for metrics exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorMetrics(tts TestTelemetry, processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
+func CheckProcessorMetrics(tts TestTelemetry, processor component.ID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
 	return tts.otelPrometheusChecker.checkProcessorMetrics(processor, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints)
 }
 
 // CheckProcessorLogs checks that for the current exported values for logs exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorLogs(tts TestTelemetry, processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
+func CheckProcessorLogs(tts TestTelemetry, processor component.ID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
 	return tts.otelPrometheusChecker.checkProcessorLogs(processor, acceptedLogRecords, refusedLogRecords, droppedLogRecords)
 }
 

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -33,8 +33,9 @@ const (
 
 var (
 	scraper  = component.NewID("fakeScraper")
-	receiver = component.NewID("fakeReicever")
-	exporter = component.NewID("fakeExporter")
+	receiver = config.NewComponentID("fakeReicever")
+	processor = config.NewComponentID("fakeProcessor")
+	exporter = config.NewComponentID("fakeExporter")
 )
 
 func TestCheckScraperMetricsViews(t *testing.T) {
@@ -119,6 +120,78 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 	assert.Error(t, obsreporttest.CheckReceiverLogs(tt, receiver, transport, 7, 7))
 	assert.Error(t, obsreporttest.CheckReceiverLogs(tt, receiver, transport, 0, 0))
 	assert.Error(t, obsreporttest.CheckReceiverLogs(tt, receiver, transport, 0, 7))
+}
+
+func TestCheckProcessorTracesViews(t *testing.T) {
+	tt, err := obsreporttest.SetupTelemetry()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+
+	por := obsreport.NewProcessor(obsreport.ProcessorSettings{
+		ProcessorID:             processor,
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+	})
+
+	por.TracesAccepted(context.Background(), 7)
+	por.TracesRefused(context.Background(), 8)
+	por.TracesDropped(context.Background(), 9)
+
+	assert.NoError(t, obsreporttest.CheckProcessorTraces(tt, processor, 7, 8, 9))
+	assert.Error(t, obsreporttest.CheckProcessorTraces(tt, processor, 0, 0, 0))
+	assert.Error(t, obsreporttest.CheckProcessorTraces(tt, processor, 7, 0, 0))
+	assert.Error(t, obsreporttest.CheckProcessorTraces(tt, processor, 7, 8, 0))
+	assert.Error(t, obsreporttest.CheckProcessorTraces(tt, processor, 7, 0, 9))
+	assert.Error(t, obsreporttest.CheckProcessorTraces(tt, processor, 0, 8, 0))
+	assert.Error(t, obsreporttest.CheckProcessorTraces(tt, processor, 0, 8, 9))
+	assert.Error(t, obsreporttest.CheckProcessorTraces(tt, processor, 0, 0, 9))
+}
+
+func TestCheckProcessorMetricsViews(t *testing.T) {
+	tt, err := obsreporttest.SetupTelemetry()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+
+	por := obsreport.NewProcessor(obsreport.ProcessorSettings{
+		ProcessorID:             processor,
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+	})
+
+	por.MetricsAccepted(context.Background(), 7)
+	por.MetricsRefused(context.Background(), 8)
+	por.MetricsDropped(context.Background(), 9)
+
+	assert.NoError(t, obsreporttest.CheckProcessorMetrics(tt, processor, 7, 8, 9))
+	assert.Error(t, obsreporttest.CheckProcessorMetrics(tt, processor, 0, 0, 0))
+	assert.Error(t, obsreporttest.CheckProcessorMetrics(tt, processor, 7, 0, 0))
+	assert.Error(t, obsreporttest.CheckProcessorMetrics(tt, processor, 7, 8, 0))
+	assert.Error(t, obsreporttest.CheckProcessorMetrics(tt, processor, 7, 0, 9))
+	assert.Error(t, obsreporttest.CheckProcessorMetrics(tt, processor, 0, 8, 0))
+	assert.Error(t, obsreporttest.CheckProcessorMetrics(tt, processor, 0, 8, 9))
+	assert.Error(t, obsreporttest.CheckProcessorMetrics(tt, processor, 0, 0, 9))
+}
+
+func TestCheckProcessorLogViews(t *testing.T) {
+	tt, err := obsreporttest.SetupTelemetry()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+
+	por := obsreport.NewProcessor(obsreport.ProcessorSettings{
+		ProcessorID:             processor,
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
+	})
+
+	por.LogsAccepted(context.Background(), 7)
+	por.LogsRefused(context.Background(), 8)
+	por.LogsDropped(context.Background(), 9)
+
+	assert.NoError(t, obsreporttest.CheckProcessorLogs(tt, processor, 7, 8, 9))
+	assert.Error(t, obsreporttest.CheckProcessorLogs(tt, processor, 0, 0, 0))
+	assert.Error(t, obsreporttest.CheckProcessorLogs(tt, processor, 7, 0, 0))
+	assert.Error(t, obsreporttest.CheckProcessorLogs(tt, processor, 7, 8, 0))
+	assert.Error(t, obsreporttest.CheckProcessorLogs(tt, processor, 7, 0, 9))
+	assert.Error(t, obsreporttest.CheckProcessorLogs(tt, processor, 0, 8, 0))
+	assert.Error(t, obsreporttest.CheckProcessorLogs(tt, processor, 0, 8, 9))
+	assert.Error(t, obsreporttest.CheckProcessorLogs(tt, processor, 0, 0, 9))
 }
 
 func TestCheckExporterTracesViews(t *testing.T) {

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -33,9 +33,9 @@ const (
 
 var (
 	scraper  = component.NewID("fakeScraper")
-	receiver = config.NewComponentID("fakeReicever")
-	processor = config.NewComponentID("fakeProcessor")
-	exporter = config.NewComponentID("fakeExporter")
+	receiver = component.NewID("fakeReicever")
+	processor= component.NewID("fakeProcessor")
+	exporter = component.NewID("fakeExporter")
 )
 
 func TestCheckScraperMetricsViews(t *testing.T) {
@@ -127,10 +127,11 @@ func TestCheckProcessorTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	por := obsreport.NewProcessor(obsreport.ProcessorSettings{
+	por, err := obsreport.NewProcessor(obsreport.ProcessorSettings{
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
+	assert.NoError(t, err)
 
 	por.TracesAccepted(context.Background(), 7)
 	por.TracesRefused(context.Background(), 8)
@@ -151,10 +152,11 @@ func TestCheckProcessorMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	por := obsreport.NewProcessor(obsreport.ProcessorSettings{
+	por, err := obsreport.NewProcessor(obsreport.ProcessorSettings{
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
+	assert.NoError(t, err)
 
 	por.MetricsAccepted(context.Background(), 7)
 	por.MetricsRefused(context.Background(), 8)
@@ -175,10 +177,11 @@ func TestCheckProcessorLogViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	por := obsreport.NewProcessor(obsreport.ProcessorSettings{
+	por, err := obsreport.NewProcessor(obsreport.ProcessorSettings{
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
+	assert.NoError(t, err)
 
 	por.LogsAccepted(context.Background(), 7)
 	por.LogsRefused(context.Background(), 8)

--- a/obsreport/obsreporttest/otelprometheuschecker.go
+++ b/obsreport/obsreporttest/otelprometheuschecker.go
@@ -62,7 +62,7 @@ func (pc *prometheusChecker) checkReceiverMetrics(receiver component.ID, protoco
 		pc.checkCounter("receiver_refused_metric_points", droppedMetricPoints, receiverAttrs))
 }
 
-func (pc *prometheusChecker) checkProcessorTraces(processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
+func (pc *prometheusChecker) checkProcessorTraces(processor component.ID, acceptedSpans, refusedSpans, droppedSpans int64) error {
 	processorAttrs := attributesForProcessorMetrics(processor)
 	return multierr.Combine(
 		pc.checkCounter("processor_accepted_spans", acceptedSpans, processorAttrs),
@@ -70,7 +70,7 @@ func (pc *prometheusChecker) checkProcessorTraces(processor config.ComponentID, 
 		pc.checkCounter("processor_dropped_spans", droppedSpans, processorAttrs))
 }
 
-func (pc *prometheusChecker) checkProcessorMetrics(processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
+func (pc *prometheusChecker) checkProcessorMetrics(processor component.ID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
 	processorAttrs := attributesForProcessorMetrics(processor)
 	return multierr.Combine(
 		pc.checkCounter("processor_accepted_metric_points", acceptedMetricPoints, processorAttrs),
@@ -78,7 +78,7 @@ func (pc *prometheusChecker) checkProcessorMetrics(processor config.ComponentID,
 		pc.checkCounter("processor_dropped_metric_points", droppedMetricPoints, processorAttrs))
 }
 
-func (pc *prometheusChecker) checkProcessorLogs(processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
+func (pc *prometheusChecker) checkProcessorLogs(processor component.ID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
 	processorAttrs := attributesForProcessorMetrics(processor)
 	return multierr.Combine(
 		pc.checkCounter("processor_accepted_log_records", acceptedLogRecords, processorAttrs),
@@ -86,7 +86,7 @@ func (pc *prometheusChecker) checkProcessorLogs(processor config.ComponentID, ac
 		pc.checkCounter("processor_dropped_log_records", droppedLogRecords, processorAttrs))
 }
 
-func (pc *prometheusChecker) checkExporterTraces(exporter config.ComponentID, sentSpans, sendFailedSpans int64) error {
+func (pc *prometheusChecker) checkExporterTraces(exporter component.ID, sentSpans, sendFailedSpans int64) error {
 	exporterAttrs := attributesForExporterMetrics(exporter)
 	return multierr.Combine(
 		pc.checkCounter("exporter_sent_spans", sentSpans, exporterAttrs),
@@ -191,7 +191,7 @@ func attributesForReceiverMetrics(receiver component.ID, transport string) []att
 	}
 }
 
-func attributesForProcessorMetrics(processor config.ComponentID) []attribute.KeyValue {
+func attributesForProcessorMetrics(processor component.ID) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String(processorTag.Name(), processor.String()),
 	}

--- a/obsreport/obsreporttest/otelprometheuschecker.go
+++ b/obsreport/obsreporttest/otelprometheuschecker.go
@@ -62,7 +62,31 @@ func (pc *prometheusChecker) checkReceiverMetrics(receiver component.ID, protoco
 		pc.checkCounter("receiver_refused_metric_points", droppedMetricPoints, receiverAttrs))
 }
 
-func (pc *prometheusChecker) checkExporterTraces(exporter component.ID, sentSpans, sendFailedSpans int64) error {
+func (pc *prometheusChecker) checkProcessorTraces(processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
+	processorAttrs := attributesForProcessorMetrics(processor)
+	return multierr.Combine(
+		pc.checkCounter("processor_accepted_spans", acceptedSpans, processorAttrs),
+		pc.checkCounter("processor_refused_spans", refusedSpans, processorAttrs),
+		pc.checkCounter("processor_dropped_spans", droppedSpans, processorAttrs))
+}
+
+func (pc *prometheusChecker) checkProcessorMetrics(processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
+	processorAttrs := attributesForProcessorMetrics(processor)
+	return multierr.Combine(
+		pc.checkCounter("processor_accepted_metric_points", acceptedMetricPoints, processorAttrs),
+		pc.checkCounter("processor_refused_metric_points", refusedMetricPoints, processorAttrs),
+		pc.checkCounter("processor_dropped_metric_points", droppedMetricPoints, processorAttrs))
+}
+
+func (pc *prometheusChecker) checkProcessorLogs(processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
+	processorAttrs := attributesForProcessorMetrics(processor)
+	return multierr.Combine(
+		pc.checkCounter("processor_accepted_log_records", acceptedLogRecords, processorAttrs),
+		pc.checkCounter("processor_refused_log_records", refusedLogRecords, processorAttrs),
+		pc.checkCounter("processor_dropped_log_records", droppedLogRecords, processorAttrs))
+}
+
+func (pc *prometheusChecker) checkExporterTraces(exporter config.ComponentID, sentSpans, sendFailedSpans int64) error {
 	exporterAttrs := attributesForExporterMetrics(exporter)
 	return multierr.Combine(
 		pc.checkCounter("exporter_sent_spans", sentSpans, exporterAttrs),
@@ -164,6 +188,12 @@ func attributesForReceiverMetrics(receiver component.ID, transport string) []att
 	return []attribute.KeyValue{
 		attribute.String(receiverTag.Name(), receiver.String()),
 		attribute.String(transportTag.Name(), transport),
+	}
+}
+
+func attributesForProcessorMetrics(processor config.ComponentID) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String(processorTag.Name(), processor.String()),
 	}
 }
 


### PR DESCRIPTION
Description:

This PR instruments obsreport.Processor with otel go. This is a followup PR that is based on similar changes made for obsreport.Receiver: https://github.com/open-telemetry/opentelemetry-collector/pull/6222

Link to tracking Issue: Part of https://github.com/open-telemetry/opentelemetry-collector/issues/816

Testing:
Ran contrib collector with memory_limiter processor and prometheusreceiver + sent traces from demo client and confirmed that new metrics show up. Tested both with feature gate disabled and enabled.

From output of $ curl localhost:8888/metrics

```
# HELP otelcol_processor_accepted_metric_points Number of metric points successfully pushed into the next component in the pipeline.
# TYPE otelcol_processor_accepted_metric_points counter
otelcol_processor_accepted_metric_points{processor="memory_limiter",service_instance_id="d957e470-f4a9-4448-b0b9-e2a2e98a2b53",service_name="otelcontribcol",service_version="v0.63.0-48-ge9099f1c57"} 298
# HELP otelcol_processor_accepted_spans Number of spans successfully pushed into the next component in the pipeline.
# TYPE otelcol_processor_accepted_spans counter
otelcol_processor_accepted_spans{processor="memory_limiter",service_instance_id="d957e470-f4a9-4448-b0b9-e2a2e98a2b53",service_name="otelcontribcol",service_version="v0.63.0-48-ge9099f1c57"} 84
# HELP otelcol_processor_dropped_metric_points Number of metric points that were dropped.
# TYPE otelcol_processor_dropped_metric_points counter
otelcol_processor_dropped_metric_points{processor="memory_limiter",service_instance_id="d957e470-f4a9-4448-b0b9-e2a2e98a2b53",service_name="otelcontribcol",service_version="v0.63.0-48-ge9099f1c57"} 0
# HELP otelcol_processor_dropped_spans Number of spans that were dropped.
# TYPE otelcol_processor_dropped_spans counter
otelcol_processor_dropped_spans{processor="memory_limiter",service_instance_id="d957e470-f4a9-4448-b0b9-e2a2e98a2b53",service_name="otelcontribcol",service_version="v0.63.0-48-ge9099f1c57"} 0
# HELP otelcol_processor_refused_metric_points Number of metric points that were rejected by the next component in the pipeline.
# TYPE otelcol_processor_refused_metric_points counter
otelcol_processor_refused_metric_points{processor="memory_limiter",service_instance_id="d957e470-f4a9-4448-b0b9-e2a2e98a2b53",service_name="otelcontribcol",service_version="v0.63.0-48-ge9099f1c57"} 0
# HELP otelcol_processor_refused_spans Number of spans that were rejected by the next component in the pipeline.
# TYPE otelcol_processor_refused_spans counter
otelcol_processor_refused_spans{processor="memory_limiter",service_instance_id="d957e470-f4a9-4448-b0b9-e2a2e98a2b53",service_name="otelcontribcol",service_version="v0.63.0-48-ge9099f1c57"} 0
```