### PR TITLE
Instrument proctelemetry.ProcessMetrics

### DIFF
--- a/service/internal/proctelemetry/process_telemetry.go
+++ b/service/internal/proctelemetry/process_telemetry.go
@@ -58,7 +58,7 @@ type processMetrics struct {
 	otelTotalAllocMem asyncint64.Counter
 	otelSysMem        asyncint64.Gauge
 	otelCpuSeconds    asyncfloat64.Counter
-	otelRssMemory     asyncint64.Gauge
+	otelRSSMemory     asyncint64.Gauge
 
 	meter             otelmetric.Meter
 	useOtelForMetrics bool
@@ -239,15 +239,15 @@ func (pm *processMetrics) recordWithOtel(ctx context.Context) error {
 		return err
 	}
 
-	pm.otelRssMemory, err = pm.meter.AsyncInt64().Gauge(
+	pm.otelRSSMemory, err = pm.meter.AsyncInt64().Gauge(
 		"process_memory_rss",
 		instrument.WithDescription("Total physical memory (resident set size)"),
 		instrument.WithUnit(unit.Bytes))
 	if err != nil {
 		return err
 	}
-	err = pm.meter.RegisterCallback([]instrument.Asynchronous{pm.otelRssMemory}, func(ctx context.Context) {
-		pm.otelRssMemory.Observe(ctx, pm.updateRSSMemory())
+	err = pm.meter.RegisterCallback([]instrument.Asynchronous{pm.otelRSSMemory}, func(ctx context.Context) {
+		pm.otelRSSMemory.Observe(ctx, pm.updateRSSMemory())
 	})
 	if err != nil {
 		return err

--- a/service/internal/proctelemetry/process_telemetry.go
+++ b/service/internal/proctelemetry/process_telemetry.go
@@ -185,7 +185,7 @@ func (pm *processMetrics) createOtelMetrics() error {
 	pm.otelProcessUptime, err = pm.meter.AsyncFloat64().Counter(
 		"process_uptime",
 		instrument.WithDescription("Uptime of the process"),
-		instrument.WithUnit(unit.Milliseconds))
+		instrument.WithUnit(unit.Unit("s")))
 	errors = multierr.Append(errors, err)
 
 	pm.otelAllocMem, err = pm.meter.AsyncInt64().Gauge(
@@ -209,7 +209,7 @@ func (pm *processMetrics) createOtelMetrics() error {
 	pm.otelCpuSeconds, err = pm.meter.AsyncFloat64().Counter(
 		"process_cpu_seconds",
 		instrument.WithDescription("Total CPU user and system time in seconds"),
-		instrument.WithUnit(unit.Milliseconds))
+		instrument.WithUnit(unit.Unit("s")))
 	errors = multierr.Append(errors, err)
 
 	pm.otelRssMemory, err = pm.meter.AsyncInt64().Gauge(
@@ -224,8 +224,7 @@ func (pm *processMetrics) createOtelMetrics() error {
 func (pm *processMetrics) recordWithOtel(ctx context.Context) error {
 	var errors, err error
 	err = pm.meter.RegisterCallback([]instrument.Asynchronous{pm.otelProcessUptime}, func(ctx context.Context) {
-		processTimeMs := 1000 * pm.updateProcessUptime()
-		pm.otelProcessUptime.Observe(ctx, processTimeMs)
+		pm.otelProcessUptime.Observe(ctx, pm.updateProcessUptime())
 	})
 	errors = multierr.Append(errors, err)
 
@@ -245,8 +244,7 @@ func (pm *processMetrics) recordWithOtel(ctx context.Context) error {
 	errors = multierr.Append(errors, err)
 
 	err = pm.meter.RegisterCallback([]instrument.Asynchronous{pm.otelCpuSeconds}, func(ctx context.Context) {
-		cpuMs := 1000 * pm.updateCPUSeconds()
-		pm.otelCpuSeconds.Observe(ctx, cpuMs)
+		pm.otelCpuSeconds.Observe(ctx, pm.updateCPUSeconds())
 	})
 	errors = multierr.Append(errors, err)
 

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -123,7 +123,7 @@ func TestOtelProcessTelemetry(t *testing.T) {
 	}
 
 	pm.meter = tel.MeterProvider.Meter("test")
-	require.NoError(t, pm.RegisterProcessMetrics(context.Background(), nil, ))
+	require.NoError(t, pm.RegisterProcessMetrics(context.Background(), nil))
 
 	mp, err := fetchPrometheusMetrics(tel.promHandler)
 	require.NoError(t, err)

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -126,10 +126,10 @@ func TestOtelProcessTelemetry(t *testing.T) {
 	pm.meter = tel.MeterProvider.Meter("test")
 	require.NoError(t, pm.RegisterProcessMetrics(context.Background(), nil))
 
-	mp, _ := fetchPrometheusMetrics(tel.promHandler)
+	mp, err := fetchPrometheusMetrics(tel.promHandler)
+	require.NoError(t, err)
 
 	for _, metricName := range tel.expectedMetrics {
-		_, _ = view.RetrieveData(metricName)
 		metric, ok := mp[metricName]
 		require.True(t, ok)
 		require.True(t, len(metric.Metric) == 1)

--- a/service/service.go
+++ b/service/service.go
@@ -212,6 +212,7 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 	}
 
 	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
+		// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
 		if err = proctelemetry.RegisterProcessMetrics(context.Background(), srv.telemetryInitializer.ocRegistry, srv.telemetryInitializer.mp, srv.telemetryInitializer.registry, getBallastSize(srv.host)); err != nil {
 			return fmt.Errorf("failed to register process metrics: %w", err)
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -25,12 +25,15 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+<<<<<<< HEAD
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
+=======
+>>>>>>> e98ccc24 (refactor and add basic test)
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/internal/proctelemetry"
 	"go.opentelemetry.io/collector/service/telemetry"
@@ -212,16 +215,10 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 		return fmt.Errorf("cannot build pipelines: %w", err)
 	}
 
-	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
-		// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
-		if srv.telemetryInitializer.registry.IsEnabled(obsreportconfig.UseOtelForInternalMetricsfeatureGateID) {
-			if err = proctelemetry.OtelRegisterProcessMetrics(context.Background(), srv.telemetrySettings, getBallastSize(srv.host)); err != nil {
-				return fmt.Errorf("failed to register process metrics: %w", err)
-			}
-		} else { // use OC metrics
-			if err = proctelemetry.RegisterProcessMetrics(srv.telemetryInitializer.ocRegistry, getBallastSize(srv.host)); err != nil {
-				return fmt.Errorf("failed to register process metrics: %w", err)
-			}
+	if set.Config.Service.Telemetry.Metrics.Level != configtelemetry.LevelNone && set.Config.Service.Telemetry.Metrics.Address != "" {
+		processMetrics := proctelemetry.NewProcessMetrics(srv.telemetrySettings.Logger, srv.telemetryInitializer.registry, srv.telemetryInitializer.mp, getBallastSize(srv.host))
+		if err = processMetrics.RegisterProcessMetrics(context.Background(), srv.telemetryInitializer.ocRegistry); err != nil {
+			return fmt.Errorf("failed to register process metrics: %w", err)
 		}
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -25,15 +25,11 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
-<<<<<<< HEAD
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
-	"go.opentelemetry.io/collector/internal/obsreportconfig"
-=======
->>>>>>> e98ccc24 (refactor and add basic test)
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/internal/proctelemetry"
 	"go.opentelemetry.io/collector/service/telemetry"
@@ -215,8 +211,8 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 		return fmt.Errorf("cannot build pipelines: %w", err)
 	}
 
-	if set.Config.Service.Telemetry.Metrics.Level != configtelemetry.LevelNone && set.Config.Service.Telemetry.Metrics.Address != "" {
-		processMetrics := proctelemetry.NewProcessMetrics(srv.telemetrySettings.Logger, srv.telemetryInitializer.registry, srv.telemetryInitializer.mp, getBallastSize(srv.host))
+	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
+		processMetrics := proctelemetry.NewProcessMetrics(srv.telemetryInitializer.registry, srv.telemetryInitializer.mp, getBallastSize(srv.host))
 		if err = processMetrics.RegisterProcessMetrics(context.Background(), srv.telemetryInitializer.ocRegistry); err != nil {
 			return fmt.Errorf("failed to register process metrics: %w", err)
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -212,8 +212,7 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 	}
 
 	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
-		processMetrics := proctelemetry.NewProcessMetrics(srv.telemetryInitializer.registry, srv.telemetryInitializer.mp, getBallastSize(srv.host))
-		if err = processMetrics.RegisterProcessMetrics(context.Background(), srv.telemetryInitializer.ocRegistry); err != nil {
+		if err = proctelemetry.RegisterProcessMetrics(context.Background(), srv.telemetryInitializer.ocRegistry, srv.telemetryInitializer.mp, srv.telemetryInitializer.registry, getBallastSize(srv.host)); err != nil {
 			return fmt.Errorf("failed to register process metrics: %w", err)
 		}
 	}


### PR DESCRIPTION
Description:

This PR instruments proctelemetry.ProcessMetrics with otel go. This is a followup PR that is based on similar changes made for obsreport.Receiver: https://github.com/open-telemetry/opentelemetry-collector/pull/6222

Link to tracking Issue: Part of https://github.com/open-telemetry/opentelemetry-collector/issues/816

Testing:
Built otelcorecol binary and checked metrics endpoint. Tested with and without featuregate.
```
% curl localhost:8888/metrics
# HELP otelcol_process_cpu_seconds_total Total CPU user and system time in seconds
# TYPE otelcol_process_cpu_seconds_total counter
otelcol_process_cpu_seconds_total 27750
# HELP otelcol_process_memory_rss_total Total physical memory (resident set size)
# TYPE otelcol_process_memory_rss_total counter
otelcol_process_memory_rss_total 7.585792e+06
# HELP otelcol_process_runtime_heap_alloc_bytes_total Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
# TYPE otelcol_process_runtime_heap_alloc_bytes_total counter
otelcol_process_runtime_heap_alloc_bytes_total 5.40590824e+08
# HELP otelcol_process_runtime_total_alloc_bytes_total Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
# TYPE otelcol_process_runtime_total_alloc_bytes_total counter
otelcol_process_runtime_total_alloc_bytes_total 5.79787416e+08
# HELP otelcol_process_runtime_total_sys_memory_bytes_total Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
# TYPE otelcol_process_runtime_total_sys_memory_bytes_total counter
otelcol_process_runtime_total_sys_memory_bytes_total 5.7855912e+08
# HELP otelcol_process_uptime_total Uptime of the process
# TYPE otelcol_process_uptime_total counter
otelcol_process_uptime_total 6.1469136692e+07
# HELP otelcol_target_info Target metadata
# TYPE otelcol_target_info gauge
otelcol_target_info{service_instance_id="2d918231-c9f3-414c-9aa6-f2c7fe382825",service_name="otelcorecol",service_version="0.65.0-dev"} 1
```