### PR TITLE
Enable create settings to access resource attributes

### DIFF
--- a/component/componenttest/nop_telemetry.go
+++ b/component/componenttest/nop_telemetry.go
@@ -30,5 +30,6 @@ func NewNopTelemetrySettings() component.TelemetrySettings {
 		TracerProvider: trace.NewNoopTracerProvider(),
 		MeterProvider:  metric.NewNoopMeterProvider(),
 		MetricsLevel:   configtelemetry.LevelNone,
+		ResourceAttrs:  map[string]string{},
 	}
 }

--- a/component/componenttest/nop_telemetry_test.go
+++ b/component/componenttest/nop_telemetry_test.go
@@ -34,4 +34,5 @@ func TestNewNopTelemetrySettings(t *testing.T) {
 		nts.MeterProvider.Meter("test")
 	})
 	assert.Equal(t, configtelemetry.LevelNone, nts.MetricsLevel)
+	assert.Len(t, nts.ResourceAttrs, 0)
 }

--- a/component/telemetry.go
+++ b/component/telemetry.go
@@ -36,4 +36,7 @@ type TelemetrySettings struct {
 	// MetricsLevel controls the level of detail for metrics emitted by the collector.
 	// Experimental: *NOTE* this field is experimental and may be changed or removed.
 	MetricsLevel configtelemetry.Level
+
+	// ResourceAttrs contains the resource attributes for the collector's telemetry.
+	ResourceAttrs map[string]string
 }

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -28,6 +28,7 @@ import (
 type nopExtension struct {
 	component.StartFunc
 	component.ShutdownFunc
+	CreateSettings
 }
 
 func TestNewFactory(t *testing.T) {
@@ -91,7 +92,6 @@ func TestMakeFactoryMap(t *testing.T) {
 func TestBuilder(t *testing.T) {
 	const typeStr = "test"
 	defaultCfg := struct{}{}
-	nopExtensionInstance := new(nopExtension)
 	testID := component.NewID(typeStr)
 	unknownID := component.NewID("unknown")
 
@@ -100,7 +100,7 @@ func TestBuilder(t *testing.T) {
 			typeStr,
 			func() component.Config { return &defaultCfg },
 			func(ctx context.Context, settings CreateSettings, extension component.Config) (Extension, error) {
-				return nopExtensionInstance, nil
+				return nopExtension{CreateSettings: settings}, nil
 			},
 			component.StabilityLevelDevelopment),
 	}...)
@@ -112,6 +112,11 @@ func TestBuilder(t *testing.T) {
 	e, err := b.Create(context.Background(), createSettings(testID))
 	assert.NoError(t, err)
 	assert.NotNil(t, e)
+
+	// Check that the extension has access to the resource attributes.
+	nop, ok := e.(nopExtension)
+	assert.True(t, ok)
+	assert.Len(t, nop.CreateSettings.ResourceAttrs, 0)
 
 	missingType, err := b.Create(context.Background(), createSettings(unknownID))
 	assert.EqualError(t, err, "extension factory not available for: \"unknown\"")

--- a/service/service.go
+++ b/service/service.go
@@ -20,8 +20,6 @@ import (
 	"runtime"
 
 	"github.com/google/uuid"
-	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
-
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -34,6 +32,7 @@ import (
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
+	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
 	"go.opentelemetry.io/collector/service/extensions"
 	"go.opentelemetry.io/collector/service/internal/graph"
 	"go.opentelemetry.io/collector/service/internal/proctelemetry"

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/google/uuid"
+	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -99,14 +102,18 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get logger: %w", err)
 	}
+
 	srv.telemetrySettings = component.TelemetrySettings{
 		Logger:         srv.telemetry.Logger(),
 		TracerProvider: srv.telemetry.TracerProvider(),
 		MeterProvider:  metric.NewNoopMeterProvider(),
 		MetricsLevel:   cfg.Telemetry.Metrics.Level,
+
+		// Construct telemetry attributes from build info and config's resource attributes.
+		ResourceAttrs: buildTelAttrs(set.BuildInfo, cfg.Telemetry),
 	}
 
-	if err = srv.telemetryInitializer.init(set.BuildInfo, srv.telemetrySettings.Logger, cfg.Telemetry, set.AsyncErrorChannel); err != nil {
+	if err = srv.telemetryInitializer.init(srv.telemetrySettings.ResourceAttrs, srv.telemetrySettings.Logger, cfg.Telemetry, set.AsyncErrorChannel); err != nil {
 		return nil, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
 	srv.telemetrySettings.MeterProvider = srv.telemetryInitializer.mp
@@ -235,4 +242,35 @@ func getBallastSize(host component.Host) uint64 {
 		}
 	}
 	return 0
+}
+
+func buildTelAttrs(buildInfo component.BuildInfo, cfg telemetry.Config) map[string]string {
+	telAttrs := map[string]string{}
+
+	for k, v := range cfg.Resource {
+		// nil value indicates that the attribute should not be included in the telemetry.
+		if v != nil {
+			telAttrs[k] = *v
+		}
+	}
+
+	if _, ok := cfg.Resource[semconv.AttributeServiceName]; !ok {
+		// AttributeServiceName is not specified in the config. Use the default service name.
+		telAttrs[semconv.AttributeServiceName] = buildInfo.Command
+	}
+
+	if _, ok := cfg.Resource[semconv.AttributeServiceInstanceID]; !ok {
+		// AttributeServiceInstanceID is not specified in the config. Auto-generate one.
+		instanceUUID, _ := uuid.NewRandom()
+		instanceID := instanceUUID.String()
+		telAttrs[semconv.AttributeServiceInstanceID] = instanceID
+	}
+
+	if _, ok := cfg.Resource[semconv.AttributeServiceVersion]; !ok {
+		// AttributeServiceVersion is not specified in the config. Use the actual
+		// build version.
+		telAttrs[semconv.AttributeServiceVersion] = buildInfo.Version
+	}
+
+	return telAttrs
 }

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -148,8 +148,8 @@ func TestTelemetryInit(t *testing.T) {
 					Address: testutil.GetAvailableLocalAddress(t),
 				},
 			}
-
-			err := tel.init(buildInfo, zap.NewNop(), cfg, make(chan error))
+			telAttrs := buildTelAttrs(buildInfo, cfg)
+			err := tel.init(telAttrs, zap.NewNop(), cfg, make(chan error))
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, tel.shutdown())


### PR DESCRIPTION
Adds a ResourceAttrs field to `component.TelemetrySettings` which exists in each `CreateSettings` object. This means that a component will be access instantiated resource attributes upon pipeline creation.